### PR TITLE
V1.0.8 Add AlphaBetaPlayer with minimax search and alpha-beta pruning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,5 +32,39 @@ jobs:
           key: v1-dependencies-{{ checksum "build.sbt" }}
 
       - run:
-          name: Test
-          command: sbt test
+          name: Test (fast)
+          command: sbt "testOnly -- -l org.scalatest.tags.Slow"
+
+  slow-tests:
+    docker:
+      - image: cimg/openjdk:17.0
+
+    working_directory: ~/repo
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.sbt" }}
+            - v1-dependencies-
+
+      - run:
+          name: Test (slow)
+          command: sbt "testOnly -- -n org.scalatest.tags.Slow"
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build
+      - slow-tests:
+          requires:
+            - build
+          filters:
+            branches:
+              only: main

--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -36,7 +36,7 @@ the project.
 ## Enforcement
 
 Instances of unacceptable behaviour may be reported to the project maintainer
-at r.hillyard@northeastern.edu. All reports will be reviewed promptly and
+at <r.hillyard@northeastern.edu>. All reports will be reviewed promptly and
 confidentially. The maintainer reserves the right to remove comments, close
 issues, or ban contributors who violate this code of conduct.
 

--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+## Our Pledge
+
+Gambit is an educational project used in university courses on AI and
+game-playing algorithms. Everyone who participates — whether as a student,
+contributor, or reader — deserves a respectful and constructive environment.
+
+We pledge to make participation in this project a harassment-free experience
+for everyone, regardless of age, background, experience level, nationality,
+or any other personal characteristic.
+
+## Our Standards
+
+**Encouraged behaviour:**
+
+- Asking questions, however basic — this is a learning environment
+- Giving and receiving constructive code review
+- Crediting others' ideas and prior work
+- Disagreeing with ideas respectfully and with evidence
+- Focusing on what is best for the project and its learners
+
+**Unacceptable behaviour:**
+
+- Personal attacks, insults, or dismissive language
+- Harassment of any kind, public or private
+- Dismissing questions as "obvious" or "already answered"
+- Publishing others' private information without consent
+
+## Scope
+
+This code of conduct applies to all project spaces: the GitHub repository,
+issues, pull requests, discussions, and any other communication related to
+the project.
+
+## Enforcement
+
+Instances of unacceptable behaviour may be reported to the project maintainer
+at r.hillyard@northeastern.edu. All reports will be reviewed promptly and
+confidentially. The maintainer reserves the right to remove comments, close
+issues, or ban contributors who violate this code of conduct.
+
+## Attribution
+
+This code of conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,4 +80,4 @@ Add AlphaBetaPlayer with minimax search and alpha-beta pruning
 
 ## Questions
 
-Open a GitHub issue or contact r.hillyard@northeastern.edu.
+Open a GitHub issue or contact <r.hillyard@northeastern.edu>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to Gambit
+
+Thank you for your interest in contributing! Gambit is primarily an
+educational project, so contributions that improve clarity, correctness,
+or pedagogical value are especially welcome.
+
+## What We Welcome
+
+- **Bug fixes** — particularly in game logic, heuristics, or search
+- **New games** — anything that fits the `State[P,S]` / `Game[S,M,Pl]`
+  typeclass pair (Chess is the natural next step)
+- **New player types** — e.g. heuristic rollouts for MCTS, iterative
+  deepening for AlphaBeta
+- **Documentation improvements** — clearer Scaladoc, better examples
+- **Test coverage** — especially for edge cases in bitboard logic or
+  search correctness
+- **Performance improvements** — provided they do not sacrifice readability
+
+## What We Are Not Looking For (Right Now)
+
+- UI or visualisation layers
+- Dependencies on large external frameworks
+- Changes that break the generic typeclass structure
+
+If you are unsure whether your idea fits, open an issue first and describe
+what you have in mind.
+
+## How to Contribute
+
+1. **Fork** the repository and create a branch from `master`:
+   ```
+   git checkout -b my-feature
+   ```
+
+2. **Write tests first** where possible. All new code should be covered
+   by unit tests in the appropriate `*Spec.scala` file.
+
+3. **Follow the existing conventions:**
+    - Scala 3 syntax throughout (no Scala 2 compat idioms)
+    - `case class` for immutable state, mutable `var` only where justified
+      (see `MCTSNode` and `AlphaBetaPlayer` for precedents)
+    - Scaladoc on all public methods and classes
+    - Tag slow tests (`playGames` with many iterations) with
+      `taggedAs org.scalatest.tagobjects.Slow`
+
+4. **Check the heuristic convention** before touching any `heuristic`
+   method or `AlphaBetaPlayer`: `heuristic(s)` must be positive when the
+   player who *just moved* to reach `s` is doing well. Violating this
+   convention silently produces wrong search behaviour. See
+   `GamePlayingDesign.md` for details.
+
+5. **Run the test suite** before submitting:
+   ```
+   sbt test
+   ```
+   CircleCI will also run the slow tests on merge to `master`.
+
+6. **Open a pull request** against `master` with a clear description of
+   what changed and why. Reference any related issues.
+
+## Commit Messages
+
+Follow the style used in the project history: a short imperative summary
+line, then a bullet list of specifics if needed. Examples:
+
+```
+Add AlphaBetaPlayer with minimax search and alpha-beta pruning
+
+- Implement generic AlphaBetaPlayer[P, S, M, Pl] with configurable depth
+- Fix initial alpha bound: use -Double.MaxValue, not Double.MinValue
+- Add AlphaBetaPlayerSpec covering TicTacToe and Connect4
+```
+
+## Code Style
+
+- 2-space indentation
+- `private` everything that doesn't need to be public
+- Prefer `val` and immutable collections; justify any `var` with a comment
+- No magic numbers — name your constants
+
+## Questions
+
+Open a GitHub issue or contact r.hillyard@northeastern.edu.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Player             P     W     D     L    GD   Pts
 
 ## API Documentation
 
-Full Scaladoc at: https://rchillyard.github.io/Gambit/latest/api/
+Full Scaladoc at: <https://rchillyard.github.io/Gambit/latest/api/>
 
 To regenerate and publish:
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/df51f96dfeac4f8c8ec796b7e91eac7c)](https://app.codacy.com/gh/rchillyard/Gambit/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/rchillyard/Gambit/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/rchillyard/Gambit/tree/main)
 ![GitHub Top Languages](https://img.shields.io/github/languages/top/rchillyard/Gambit)
-![GitHub](https://img.shields.io/github/license/rchillyard/Gambit)
+![License: MIT](https://img.shields.io/github/license/rchillyard/Gambit)
 ![GitHub last commit](https://img.shields.io/github/last-commit/rchillyard/Gambit)
 ![GitHub issues](https://img.shields.io/github/issues-raw/rchillyard/Gambit)
 ![GitHub issues by-label](https://img.shields.io/github/issues/rchillyard/Gambit/bug)
@@ -14,8 +14,9 @@ A Scala 3 framework for game-playing tree search and reinforcement learning.
 ## Overview
 
 Gambit provides a generic, typeclass-driven infrastructure for game-playing
-strategies. It supports minimax, Monte Carlo Tree Search (MCTS), and reinforcement
-learning (MENACE), with fully worked implementations for TicTacToe and Connect Four.
+strategies. It supports minimax with alpha-beta pruning, Monte Carlo Tree Search
+(MCTS), and reinforcement learning (MENACE), with fully worked implementations
+for TicTacToe and Connect Four.
 
 The framework depends on [Visitor](https://github.com/rchillyard/Visitor) for
 its graph and tree traversal engine.
@@ -25,7 +26,7 @@ its graph and tree traversal engine.
 Gambit is published to Maven Central. Add the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.phasmidsoftware" %% "gambit" % "1.0.7"
+libraryDependencies += "com.phasmidsoftware" %% "gambit" % "1.0.8"
 ```
 
 Requires Scala 3. Depends on [Visitor](https://github.com/rchillyard/Visitor) 1.6.0,
@@ -42,15 +43,20 @@ which is pulled in automatically as a transitive dependency.
 - `Player[S, M, Pl]` — trait for player strategy: `chooseMove`, `gameOver`
 - `GameRunner[P, S, M, Pl]` — generic game execution driven by `State` and `Game` givens
 - `GameResult[Pl]` / `MatchResult[Pl]` — per-game and per-match result types
+- `AlphaBetaPlayer[P, S, M, Pl]` — generic minimax player with alpha-beta pruning
+  and move ordering; configurable depth
 - `MCTSPlayer[P, S, M, Pl]` — generic Monte Carlo Tree Search player with UCB1
+  and tree reuse between moves
+- `Tournament[P, S, M, Pl]` / `Contestant[S, M, Pl]` — round-robin league with
+  3-1-0 scoring and a formatted league table
 
 ### TicTacToe (`com.phasmidsoftware.gambit.examples.tictactoe`)
 
 - `TicTacToe` / `Board` — compact bitboard representation with rotation,
   transposition, and a rich heuristic hierarchy
 - `TicTacToeOps` — low-level Java bit manipulation (rotate, transpose, play, render)
-- Five player types: `RandomPlayer`, `HeuristicPlayer`, `MenacePlayer`,
-  `PerfectPlayer`, and `MCTSPlayer`
+- Six player types: `RandomPlayer`, `HeuristicPlayer`, `MenacePlayer`,
+  `PerfectPlayer`, `AlphaBetaPlayer`, and `MCTSPlayer`
 - `given tictactoeGame` — wires TicTacToe into the generic `Game` typeclass
 - `TicTacToeDemo` — `@main` program playing home/away matches between all player types
 
@@ -73,8 +79,10 @@ is evaluated exactly once (DAG, not tree). Never loses; always draws against its
 
 - `Connect4` — column-major bitboard with gravity, sentinel-bit win detection
 - `Connect4State` — `State[Connect4, Connect4]` with window-scoring heuristic
-- Three player types: `RandomPlayer`, `HeuristicPlayer`, `MCTSPlayer`
+- Four player types: `RandomPlayer`, `HeuristicPlayer`, `AlphaBetaPlayer`,
+  and `MCTSPlayer`
 - `given connect4Game` — wires Connect Four into the generic `Game` typeclass
+- `Connect4Tournament` — round-robin tournament between all player types
 - `Connect4Demo` — `@main` program playing home/away matches between player types
 
 ## Demo Programs
@@ -95,17 +103,52 @@ Move 1 (X plays cell 4 — row 1, col 1):
 Result: X (Perfect) wins!
 ```
 
+## Tournament
+
+Run the Connect Four round-robin tournament from sbt:
+
+```
+sbt "runMain com.phasmidsoftware.gambit.examples.connect4.Connect4Tournament [gamesPerPairing] [seed]"
+```
+
+Both arguments are optional. `gamesPerPairing` defaults to 6; `seed` defaults to
+`System.currentTimeMillis()` so repeated runs produce different results unless a
+seed is specified. Sample output:
+
+```
+Connect Four Tournament (6 games per pairing)
+
+Player             P     W     D     L    GD   Pts
+--------------------------------------------------
+1. AlphaBeta(d=6)  60    48     1    11   +37   145
+2. AlphaBeta(d=4)  60    45     1    14   +31   136
+3. MCTS(i=500)     60    37     2    21   +16   113
+4. MCTS(i=200)     60    31     1    28    +3    94
+5. Heuristic       60    16     1    43   -27    49
+6. Random          60     0     0    60   -60     0
+```
+
+## API Documentation
+
+Full Scaladoc at: https://rchillyard.github.io/Gambit/latest/api/
+
+To regenerate and publish:
+```
+sbt ghpagesPushSite
+```
+
 ## Design Documents
 
 - `VisitorDesign.md` — design of the Visitor traversal engine
 - `GamePlayingDesign.md` — design of the game-playing framework: typeclasses,
-  MCTS, MENACE, Connect Four, heuristic conventions, and future directions
+  alpha-beta, MCTS with tree reuse, MENACE, Connect Four tournament, heuristic
+  conventions, and future directions
 
 ## Future Work
 
-- MCTS tree reuse between moves; actor-based parallel rollouts (Akka/Pekko)
+- Actor-based parallel rollouts for MCTS (Akka/Pekko)
+- Heuristic rollouts for stronger MCTS play
 - MENACE self-play, X/O symmetry, and persistence
-- Alpha-beta pruning for stronger Connect Four play
 - Chess — `given chessGame: Game[ChessState, ChessMove, Boolean]`
 - Bridge — `given bridgeGame: Game[BridgeState, Card, Seat]`; four-player;
   MCTS with determinization for hidden information

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.phasmidsoftware"
 
 name := "gambit"
 
-version := "1.0.7"
+version := "1.0.8"
 
 scalaVersion := "3.7.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,3 +25,7 @@ libraryDependencies ++= Seq(
   "org.scalatest"              %% "scalatest"        % scalaTestVersion % Test,
   "junit" % "junit" % "4.13.2" % "test" // Used by java unit tests
 )
+
+enablePlugins(GhpagesPlugin, SiteScaladocPlugin)
+
+git.remoteRepo := "git@github.com:rchillyard/Gambit.git"

--- a/build.sbt
+++ b/build.sbt
@@ -17,14 +17,30 @@ scalacOptions ++= Seq(
 
 javacOptions ++= Seq("-source", "17", "-target", "17")
 
+lazy val versionConfig = "1.4.8"
+lazy val versionScalaLogging = "3.9.6"
+lazy val versionLogback = "1.5.32"
+lazy val versionVisitor = "1.6.0"
+lazy val versionFlog = "1.0.13"
+
 libraryDependencies ++= Seq(
-  "com.phasmidsoftware"        %% "flog"             % "1.0.13",
-  "com.phasmidsoftware"        %% "visitor"          % "1.6.0",
-  "com.typesafe.scala-logging" %% "scala-logging"    % "3.9.6",
-  "ch.qos.logback"              % "logback-classic"  % "1.5.32" % Runtime,
+  "com.phasmidsoftware"        %% "flog"             % versionFlog,
+  "com.phasmidsoftware"        %% "visitor"          % versionVisitor,
+  "com.typesafe.scala-logging" %% "scala-logging"    % versionScalaLogging,
+  "com.typesafe"                % "config"           % versionConfig,
+  "ch.qos.logback"              % "logback-classic"  % versionLogback % Runtime,
   "org.scalatest"              %% "scalatest"        % scalaTestVersion % Test,
   "junit" % "junit" % "4.13.2" % "test" // Used by java unit tests
 )
+
+lazy val IT = config("it") extend Test
+
+lazy val root = project.in(file("."))
+  .configs(IT)
+  .settings(
+    inConfig(IT)(Defaults.testSettings),
+    IT / scalaSource := baseDirectory.value / "src" / "it" / "scala"
+  )
 
 enablePlugins(GhpagesPlugin, SiteScaladocPlugin)
 

--- a/doc/GamePlayingDesign.md
+++ b/doc/GamePlayingDesign.md
@@ -4,7 +4,8 @@
 
 This document captures the design decisions behind the game-playing framework
 in Gambit, covering the generic typeclasses in `game`, the TicTacToe
-and Connect Four implementations, and the player types including MCTS.
+and Connect Four implementations, and the player types including MCTS and
+AlphaBeta.
 
 ---
 
@@ -18,7 +19,9 @@ and Connect Four implementations, and the player types including MCTS.
 | `Game.scala` | `Game[S, M, Pl]` — game mechanics typeclass |
 | `Player.scala` | `Player[S, M, Pl]`; `GameResult[Pl]`, `MatchResult[Pl]` |
 | `GameRunner.scala` | `GameRunner[P, S, M, Pl]` — generic game execution |
+| `AlphaBetaPlayer.scala` | `AlphaBetaPlayer[P, S, M, Pl]` — minimax with alpha-beta pruning |
 | `MCTSPlayer.scala` | `MCTSPlayer[P, S, M, Pl]`, `MCTSNode[S, M, Pl]` — Monte Carlo Tree Search |
+| `Tournament.scala` | `Tournament[P, S, M, Pl]`, `Contestant[S, M, Pl]` — round-robin league |
 
 ### `com.phasmidsoftware.gambit.examples.tictactoe`
 
@@ -40,6 +43,7 @@ and Connect Four implementations, and the player types including MCTS.
 | `Connect4.scala` | `Connect4` — column-major bitboard state with gravity |
 | `Connect4State.scala` | `Connect4State` — `State[Connect4, Connect4]` instance |
 | `Connect4Game.scala` | `RandomPlayer`, `HeuristicPlayer`; `given connect4Game`; `Connect4GameRunner` |
+| `Connect4Tournament.scala` | `Connect4Tournament` — concrete tournament runner with `main` |
 | `Connect4Demo.scala` | `@main Connect4Demo` — home/away matchup demo |
 
 ---
@@ -49,13 +53,15 @@ and Connect Four implementations, and the player types including MCTS.
 ### Typeclass Hierarchy
 
 ```
-State[P, S]            — game state: legal moves, goal detection, heuristic,
-                         isFirstPlayerToMove
-Game[S, M, Pl]         — game mechanics: start, moves, applyMove, nextPlayer,
-                         currentPlayer, winner
-Player[S, M, Pl]       — player strategy: chooseMove, gameOver
-GameRunner[P, S, M, Pl] — execution: driven by State and Game givens
-MCTSPlayer[P, S, M, Pl] — generic MCTS player
+State[P, S]              — game state: legal moves, goal detection, heuristic,
+                           isFirstPlayerToMove
+Game[S, M, Pl]           — game mechanics: start, moves, applyMove, nextPlayer,
+                           currentPlayer, winner
+Player[S, M, Pl]         — player strategy: chooseMove, gameOver
+GameRunner[P, S, M, Pl]  — execution: driven by State and Game givens
+AlphaBetaPlayer[P,S,M,Pl]— generic minimax player with alpha-beta pruning
+MCTSPlayer[P, S, M, Pl]  — generic MCTS player with tree reuse
+Tournament[P, S, M, Pl]  — round-robin league with 3-1-0 scoring
 ```
 
 ### State[P, S]
@@ -88,7 +94,9 @@ A trait (not a typeclass) because players have instance identity and mutable
 state. Two methods:
 
 - `chooseMove(s, random): Option[M]` — returns `None` for terminal positions
-- `gameOver(result: GameResult[Pl], me: Pl): Unit` — default no-op
+- `gameOver(result: GameResult[Pl], me: Pl): Unit` — default no-op; overridden
+  by stateful players (e.g. `MenacePlayer`, `MCTSPlayer`) to reset or update
+  internal state between games
 
 ### GameResult[Pl] and MatchResult[Pl]
 
@@ -111,6 +119,33 @@ bridge, scores could represent tricks won per side.
 Driven entirely by `given State[P, S]` and `given Game[S, M, Pl]`. Takes only
 `playerMap: Map[Pl, Player[S, M, Pl]]` and a `Random`. Tail-recursive `loop`;
 `playGames(n)` returns a `MatchResult[Pl]`.
+
+---
+
+## AlphaBeta
+
+### AlphaBetaPlayer[P, S, M, Pl]
+
+Generic minimax player with alpha-beta pruning to a configurable depth.
+
+**Heuristic convention** — `heuristic(s)` is from the perspective of whoever
+just moved INTO `s`. `alphaBeta` returns a value from `me`'s perspective;
+leaf nodes negate the heuristic when the minimizing player just moved:
+
+```scala
+def leafValue: Double = if maximizing then -state.heuristic(s) else state.heuristic(s)
+```
+
+**Alpha-beta bounds** — initial alpha is `-Double.MaxValue` (not
+`Double.MinValue`, which is the smallest *positive* double ~5e-324).
+
+**Move ordering** — successors sorted by heuristic before recursing (highest
+first for maximizer, lowest first for minimizer), maximising the probability
+of early pruning and approaching best-case O(b^(d/2)) node count.
+
+**`maximizing` flag** — true when `currentPlayer(s) == me`; correctly handles
+positions where it is the opponent's turn at the root (e.g. when `AlphaBetaPlayer`
+is called as `me=true` but the board has an odd number of pieces).
 
 ---
 
@@ -138,6 +173,18 @@ Generic MCTS player implementing the standard four-phase loop:
 **Most-visited child** criterion for final move selection — more robust than
 highest win-rate under finite simulations.
 
+**Tree reuse** — the chosen child subtree is retained between `chooseMove`
+calls via `retainedRoot`. On the next call, `advanceTree` searches the retained
+node's children for the opponent's reply state:
+- **Cache hit** — the matching grandchild becomes the new root, carrying
+  forward all accumulated visits and wins.
+- **Cache miss** — opponent played an unexplored line; a fresh root is created.
+  `gameOver` resets `retainedRoot = None` so tree state does not leak between
+  games when the same instance is reused across a match.
+
+Tree matching uses `==` on `S`; requires meaningful equality (satisfied by
+`case class`).
+
 **`me` parameter** — the player identity this instance represents; used in
 backpropagation to correctly credit wins. Must be set to `true` (X) when
 playing as X and `false` (O) when playing as O.
@@ -147,13 +194,62 @@ who moves at the root, correctly handling mid-game positions.
 
 ### Future Upgrades
 
-- **Tree reuse** — retain the subtree rooted at the chosen move between calls,
-  avoiding redundant re-exploration of already-visited states
 - **Actor-based parallelism** — move the mutable tree into an Akka/Pekko actor;
   multiple rollout worker actors submit simulation results concurrently (root
   parallelization), giving near-linear speedup with core count
 - **Heuristic rollouts** — replace pure random simulation with heuristic-guided
   playout for stronger play
+
+---
+
+## Tournament
+
+### Tournament[P, S, M, Pl]
+
+Generic round-robin tournament. Every ordered pair of contestants plays
+`gamesPerPairing` games, so each contestant takes the first-player role
+equally often. Driven by the same `given State[P, S]` and `given Game[S, M, Pl]`
+as `GameRunner`.
+
+**Scoring** — standard football 3-1-0:
+- Win  = 3 points
+- Draw = 1 point
+- Loss = 0 points
+
+**Standings** sorted by points descending, then goal difference (wins − losses),
+then wins. `leagueTable` returns a formatted string; `standings` returns raw
+tuples for programmatic use.
+
+**`Contestant[S, M, Pl]`** — pairs a display name with a `Player` instance.
+The name is purely for the league table; players are unaware of the tournament
+context and optimise only for winning individual games.
+
+### Connect4Tournament
+
+Concrete runner in the `connect4` package. Enters six player types:
+`Random`, `Heuristic`, `AlphaBeta(d=4)`, `AlphaBeta(d=6)`, `MCTS(i=200)`,
+`MCTS(i=500)`. Runnable as a JVM main:
+
+```
+sbt "runMain com.phasmidsoftware.gambit.examples.connect4.Connect4Tournament [gamesPerPairing] [seed]"
+```
+
+Both arguments are optional. `gamesPerPairing` defaults to 6;
+`seed` defaults to `System.currentTimeMillis()` so repeated runs produce
+different results unless a seed is specified explicitly.
+
+Sample output (6 games per pairing, seed 42):
+
+```
+Player             P     W     D     L    GD   Pts
+--------------------------------------------------
+1. AlphaBeta(d=6)  60    48     1    11   +37   145
+2. AlphaBeta(d=4)  60    45     1    14   +31   136
+3. MCTS(i=500)     60    37     2    21   +16   113
+4. MCTS(i=200)     60    31     1    28    +3    94
+5. Heuristic       60    16     1    43   -27    49
+6. Random          60     0     0    60   -60     0
+```
 
 ---
 
@@ -179,7 +275,8 @@ given tictactoeGame(using State[Board, TicTacToe]): Game[TicTacToe, Int, Boolean
 | `HeuristicPlayer` | `maxBy(heuristic)` over successors |
 | `MenacePlayer` | MENACE bead reinforcement learning |
 | `PerfectPlayer` | Full minimax via Visitor post-order DFS |
-| `MCTSPlayer` | Monte Carlo Tree Search |
+| `AlphaBetaPlayer` | Minimax with alpha-beta pruning (generic) |
+| `MCTSPlayer` | Monte Carlo Tree Search with tree reuse (generic) |
 
 ### MENACE
 
@@ -249,8 +346,9 @@ given connect4Game(using State[Connect4, Connect4]): Game[Connect4, Int, Boolean
 | Player | Strategy |
 |--------|----------|
 | `RandomPlayer` | Uniform random over open columns |
-| `HeuristicPlayer` | `maxBy(heuristic)` over successors |
-| `MCTSPlayer` | Monte Carlo Tree Search |
+| `HeuristicPlayer` | `maxBy(heuristic)` over successors (one-ply greedy) |
+| `AlphaBetaPlayer` | Minimax with alpha-beta pruning (generic) |
+| `MCTSPlayer` | Monte Carlo Tree Search with tree reuse (generic) |
 
 ---
 
@@ -262,6 +360,10 @@ Both `TicTacToe` and Connect Four follow the same convention:
 > is doing well. `HeuristicPlayer.chooseMove` uses `maxBy(heuristic)` over
 > successors — since each successor was reached by the current player moving,
 > the maximum heuristic successor is the best move.
+
+`AlphaBetaPlayer` accounts for this at leaf nodes by negating the heuristic
+when the minimizing player just moved, ensuring the returned value is always
+from `me`'s perspective regardless of search depth.
 
 This was the source of several bugs during development when the convention
 was inconsistently applied between `State.heuristic` and `Player.chooseMove`.
@@ -281,15 +383,28 @@ The `playTicTacToeDemo` and `playConnect4Demo` functions return `Option[Boolean]
 
 ---
 
+## API Documentation
+
+Scaladoc is published to GitHub Pages via `sbt-ghpages`:
+
+```
+https://rchillyard.github.io/Gambit/latest/api/
+```
+
+To update after significant changes:
+```
+sbt ghpagesPushSite
+```
+
+---
+
 ## Future Work
 
-- **MCTS tree reuse** between moves
-- **Actor-based parallel rollouts** (Akka/Pekko)
+- **Actor-based parallel rollouts** (Akka/Pekko) for MCTS
+- **Heuristic rollouts** for stronger MCTS play
 - **MENACE self-play** — two instances with shared or separate registries
 - **MENACE X/O symmetry** — `exchangeBoard` to halve matchbox count
 - **MENACE persistence** — serialise registry for trained agent reuse
-- **Alpha-beta pruning** — for stronger Connect Four play (full minimax
-  is intractable for the 7×6 board)
 - **Chess** — `given chessGame: Game[ChessState, ChessMove, Boolean]`
 - **Bridge** — `given bridgeGame: Game[BridgeState, Card, Seat]`;
   four-player; `winner` returns tricks per side; MCTS with determinization

--- a/doc/GamePlayingDesign.md
+++ b/doc/GamePlayingDesign.md
@@ -212,6 +212,7 @@ equally often. Driven by the same `given State[P, S]` and `given Game[S, M, Pl]`
 as `GameRunner`.
 
 **Scoring** — standard football 3-1-0:
+
 - Win  = 3 points
 - Draw = 1 point
 - Loss = 0 points

--- a/doc/GamePlayingDesign.md
+++ b/doc/GamePlayingDesign.md
@@ -176,6 +176,7 @@ highest win-rate under finite simulations.
 **Tree reuse** — the chosen child subtree is retained between `chooseMove`
 calls via `retainedRoot`. On the next call, `advanceTree` searches the retained
 node's children for the opponent's reply state:
+
 - **Cache hit** — the matching grandchild becomes the new root, carrying
   forward all accumulated visits and wins.
 - **Cache miss** — opponent played an unexplored line; a fresh root is created.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
+addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.8.0")

--- a/src/it/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayerFuncSpec.scala
+++ b/src/it/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayerFuncSpec.scala
@@ -1,0 +1,33 @@
+package com.phasmidsoftware.gambit.game
+
+import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
+import com.phasmidsoftware.gambit.examples.connect4.{Connect4, Connect4GameRunner, Connect4State, connect4Game, HeuristicPlayer as C4HeuristicPlayer}
+import com.phasmidsoftware.gambit.examples.tictactoe.TicTacToe.TicTacToeState$
+import com.phasmidsoftware.gambit.examples.tictactoe.{Board, TicTacToe, TicTacToeGameRunner, tictactoeGame, RandomPlayer as TTTRandomPlayer}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import org.scalatest.tagobjects.Slow
+
+import scala.util.Random
+
+class AlphaBetaPlayerFuncSpec extends AnyFlatSpec with should.Matchers {
+
+  behavior of "AlphaBetaPlayer on TicTacToe"
+
+  it should "never lose as X against a random player" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 6)
+    val runner = TicTacToeGameRunner(ab, new TTTRandomPlayer, new Random(1L))
+    val stats = runner.playGames(20)
+    stats.winsFor(false) shouldBe 0
+  }
+
+  behavior of "AlphaBetaPlayer on Connect4"
+
+  it should "be stronger than HeuristicPlayer with greater depth" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 6)
+    val heuristic = new C4HeuristicPlayer
+    val runner = Connect4GameRunner(ab, heuristic, new Random(8L))
+    val stats = runner.playGames(10)
+    stats.winsFor(true) should be > stats.lossesFor(true)
+  }
+}

--- a/src/it/scala/com/phasmidsoftware/gambit/game/TournamentFuncSpec.scala
+++ b/src/it/scala/com/phasmidsoftware/gambit/game/TournamentFuncSpec.scala
@@ -1,0 +1,22 @@
+package com.phasmidsoftware.gambit.game
+
+import com.phasmidsoftware.gambit.examples.connect4.Connect4
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import org.scalatest.tagobjects.Slow
+
+class TournamentFuncSpec extends AnyFlatSpec with should.Matchers {
+
+  // Convenience alias.
+  private type C4Tournament = Tournament[Connect4, Connect4, Int, Boolean]
+
+  private def contestant(name: String, player: Player[Connect4, Int, Boolean]) =
+    Contestant(name, player)
+
+  behavior of "Tournament competitive ordering"
+
+  it should "produce a complete Connect4Tournament table without throwing" taggedAs Slow in {
+    import com.phasmidsoftware.gambit.examples.connect4.Connect4Tournament
+    noException should be thrownBy Connect4Tournament.run(gamesPerPairing = 2)
+  }
+}

--- a/src/it/scala/com/phasmidsoftware/gambit/game/TournamentFuncSpec.scala
+++ b/src/it/scala/com/phasmidsoftware/gambit/game/TournamentFuncSpec.scala
@@ -7,12 +7,6 @@ import org.scalatest.tagobjects.Slow
 
 class TournamentFuncSpec extends AnyFlatSpec with should.Matchers {
 
-  // Convenience alias.
-  private type C4Tournament = Tournament[Connect4, Connect4, Int, Boolean]
-
-  private def contestant(name: String, player: Player[Connect4, Int, Boolean]) =
-    Contestant(name, player)
-
   behavior of "Tournament competitive ordering"
 
   it should "produce a complete Connect4Tournament table without throwing" taggedAs Slow in {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,14 @@
+gambit {
+  tournament {
+    gamesPerPairing = 6
+  }
+  alphaBeta {
+    depth1 = 4
+    depth2 = 6
+  }
+  mcts {
+    iterations1 = 200
+    iterations2 = 500
+    explorationConstant = 1.4142135623730951
+  }
+}

--- a/src/main/scala/com/phasmidsoftware/gambit/attic/Output.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/attic/Output.scala
@@ -130,7 +130,7 @@ sealed trait TypedOutput extends Output {
   def append(x: OutputType): Output
 
   def :+(x: Any): Output =
-    this append asOutputType(x)
+    this.append(asOutputType(x))
 
   def ++(xs: Iterator[Output])(implicit separator: Output): Output = xs.foldLeft[Output](this)(_ ++ separator ++ _)
 }
@@ -238,7 +238,7 @@ sealed trait CharacterOutput extends TypedOutput {
   def asLine(x: Any): Output = :+(x).insertBreak()
 }
 
-sealed trait BackedOutput[A <: Appendable with AutoCloseable] extends TypedOutput {
+sealed trait BackedOutput[A <: Appendable & AutoCloseable] extends TypedOutput {
   val appendable: A
 
   /**
@@ -258,7 +258,7 @@ sealed trait BackedOutput[A <: Appendable with AutoCloseable] extends TypedOutpu
  * @param sb          the StringBuilder that we use as temporary storage of characters.
  * @tparam A the underlying (appendable) type.
  */
-sealed abstract class BufferedCharSequenceOutput[A <: Appendable with AutoCloseable with Flushable](val appendable: A, var indentation: CharSequence, val sb: mutable.StringBuilder = new StringBuilder) extends CharacterOutput with BufferedOutput with BackedOutput[A] {
+sealed abstract class BufferedCharSequenceOutput[A <: Appendable & AutoCloseable & Flushable](val appendable: A, var indentation: CharSequence, val sb: mutable.StringBuilder = new StringBuilder) extends CharacterOutput with BufferedOutput with BackedOutput[A] {
 
   val transform: CharSequence => CharSequence = identity
 
@@ -318,15 +318,13 @@ sealed abstract class BufferedCharSequenceOutput[A <: Appendable with AutoClosea
     case b: BufferedOutput =>
       if (isBacked) backedConcatenate(b)
       else concatenateOther(b)
-    case _ =>
-      throw OutputException(s"unsupported Output type: ${output.getClass}")
   }
 
   def contentBrief: String = content.toString.substring(0, Math.min(20, sb.length))
 
   private def backedConcatenate(output: BufferedOutput): Output = if (output.isBacked) {
     close()
-    val bufferedCharSequenceOutput = output.asInstanceOf[BufferedCharSequenceOutput[_]]
+    val bufferedCharSequenceOutput = output.asInstanceOf[BufferedCharSequenceOutput[?]]
     if (indentation.length > bufferedCharSequenceOutput.indentation.length)
       bufferedCharSequenceOutput.indentation = indentation
     output

--- a/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4.scala
@@ -1,7 +1,5 @@
 package com.phasmidsoftware.gambit.examples.connect4
 
-import com.phasmidsoftware.gambit.game.State
-
 /**
   * Connect Four board state using a column-major bitboard representation.
   *
@@ -12,6 +10,8 @@ import com.phasmidsoftware.gambit.game.State
   *
   * `heights` tracks the next available row index per column (0..5).
   * A column is full when heights(col) == Connect4.rows.
+  *
+  * You can read more about the game here: [[https://en.wikipedia.org/wiki/Connect_Four#cite_note-19]]
   *
   * @param xBits   bit positions of X's pieces
   * @param oBits   bit positions of O's pieces

--- a/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
@@ -32,55 +32,70 @@ object Connect4Tournament:
   def main(args: Array[String]): Unit =
     val gamesPerPairing = args.headOption.flatMap(_.toIntOption).getOrElse(GambitConfig.tournamentGamesPerPairing)
     val seed = args.lift(1).flatMap(_.toLongOption).getOrElse(System.currentTimeMillis())
-    println(run(gamesPerPairing = gamesPerPairing, seed = seed))
+    println(run(gamesPerPairing = gamesPerPairing, seed = seed, flush = () => System.out.flush()))
 
   /**
-    * Build and run the tournament, returning the league table as a String.
+    * Build and run the tournament, printing progress and returning the league table.
+    *
+    * Output is written via `out` and flushed via `flush`, both of which default to
+    * stdout behaviour. Pass alternative implementations for testing or redirection:
+    *
+    * {{{
+    *   val sb = new StringBuilder
+    *   val table = Connect4Tournament.run(
+    *     gamesPerPairing = 2, seed = 42L,
+    *     out   = s => { sb.append(s); sb.append('\n') },
+    *     flush = () => ()
+    *   )
+    * }}}
     *
     * Player parameters are read from [[GambitConfig]] (`application.conf`).
     * Override by editing the config file -- no recompilation needed.
     *
     * @param gamesPerPairing number of games each ordered pair plays
     *                        (default from config: `gambit.tournament.gamesPerPairing`).
-    *
     * @param seed            random seed; default is `System.currentTimeMillis()`.
-    * @return the formatted league table.
+    * @param out             output function for progress lines (default `println`).
+    * @param flush           flush function called after progress lines (default stdout flush).
+    * @return the formatted league table string.
     */
   def run(
-           gamesPerPairing: Int = GambitConfig.tournamentGamesPerPairing,
-           seed: Long = System.currentTimeMillis()
+           gamesPerPairing: Int            = GambitConfig.tournamentGamesPerPairing,
+           seed:            Long           = System.currentTimeMillis(),
+           out:             String => Unit = println,
+           flush:           () => Unit     = () => ()   // no-op by default
          ): String =
     val announcement = s"Connect Four Tournament ($gamesPerPairing games per pairing)"
-    val marquee = "*" * announcement.length
-    println(marquee)
-    println(announcement)
-    println(marquee)
+    val marquee      = "*" * announcement.length
+    out(marquee)
+    out(announcement)
+    out(marquee)
 
     val rng = new Random(seed)
-    val d1 = GambitConfig.alphaBetaDepth1
-    val d2 = GambitConfig.alphaBetaDepth2
-    val i1 = GambitConfig.mctsIterations1
-    val i2 = GambitConfig.mctsIterations2
-    val c = GambitConfig.mctsExplorationConstant
+    val d1  = GambitConfig.alphaBetaDepth1
+    val d2  = GambitConfig.alphaBetaDepth2
+    val i1  = GambitConfig.mctsIterations1
+    val i2  = GambitConfig.mctsIterations2
+    val c   = GambitConfig.mctsExplorationConstant
 
-    println(s"depth1=$d1, depth2=$d2, iterations1=$i1, iterations2=$i2, explorationConstant=$c")
+    out(s"depth1=$d1, depth2=$d2, iterations1=$i1, iterations2=$i2, explorationConstant=$c")
 
     val contestants = Seq(
-      Contestant("Random", new RandomPlayer),
-      Contestant("Heuristic", new HeuristicPlayer),
+      Contestant("Random",            new RandomPlayer),
+      Contestant("Heuristic",         new HeuristicPlayer),
       Contestant(s"AlphaBeta(d=$d1)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = d1)),
       Contestant(s"AlphaBeta(d=$d2)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = d2)),
-      Contestant(s"MCTS(i=$i1)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = i1, explorationConstant = c)),
-      Contestant(s"MCTS(i=$i2)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = i2, explorationConstant = c)),
+      Contestant(s"MCTS(i=$i1)",      MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = i1, explorationConstant = c)),
+      Contestant(s"MCTS(i=$i2)",      MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = i2, explorationConstant = c)),
     )
 
-    println(s"Contestants: ${contestants.map(_.name).mkString(", ")}")
-    System.out.flush()
+    out(s"Contestants: ${contestants.map(_.name).mkString(", ")}")
+    flush()
 
     val tournament = Tournament[Connect4, Connect4, Int, Boolean](
-      contestants = contestants,
+      contestants     = contestants,
       gamesPerPairing = gamesPerPairing,
-      random = rng
+      random          = rng
     )
 
     s"\n${tournament.leagueTable}"

--- a/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
@@ -1,0 +1,50 @@
+package com.phasmidsoftware.gambit.examples.connect4
+
+import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
+import com.phasmidsoftware.gambit.game.{AlphaBetaPlayer, Contestant, MCTSPlayer, Tournament}
+import scala.util.Random
+
+/**
+  * Runs a round-robin tournament between all Connect Four player types
+  * and prints the league table to stdout.
+  *
+  * Players entered:
+  *   - RandomPlayer
+  *   - HeuristicPlayer  (one-ply greedy)
+  *   - AlphaBeta(d=4)   (minimax, depth 4)
+  *   - AlphaBeta(d=6)   (minimax, depth 6)
+  *   - MCTS(i=200)      (Monte Carlo, 200 iterations)
+  *   - MCTS(i=500)      (Monte Carlo, 500 iterations)
+  */
+object Connect4Tournament:
+
+  def main(args: Array[String]): Unit =
+    val gamesPerPairing = args.headOption.flatMap(_.toIntOption).getOrElse(6)
+    println(run(gamesPerPairing = gamesPerPairing))
+
+  /**
+    * Build and run the tournament, returning the league table as a String.
+    *
+    * @param gamesPerPairing number of games each ordered pair plays (default 6).
+    * @param seed            random seed for reproducibility (default 42).
+    * @return the formatted league table.
+    */
+  def run(gamesPerPairing: Int = 6, seed: Long = 42L): String =
+    val rng = new Random(seed)
+
+    val contestants = Seq(
+      Contestant("Random",         new RandomPlayer),
+      Contestant("Heuristic",      new HeuristicPlayer),
+      Contestant("AlphaBeta(d=4)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)),
+      Contestant("AlphaBeta(d=6)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 6)),
+      Contestant("MCTS(i=200)",    MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)),
+      Contestant("MCTS(i=500)",    MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 500)),
+    )
+
+    val tournament = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants     = contestants,
+      gamesPerPairing = gamesPerPairing,
+      random          = rng
+    )
+
+    s"Connect Four Tournament ($gamesPerPairing games per pairing)\n\n${tournament.leagueTable}"

--- a/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
@@ -2,6 +2,7 @@ package com.phasmidsoftware.gambit.examples.connect4
 
 import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
 import com.phasmidsoftware.gambit.game.{AlphaBetaPlayer, Contestant, MCTSPlayer, Tournament}
+
 import scala.util.Random
 
 /**
@@ -18,9 +19,21 @@ import scala.util.Random
   */
 object Connect4Tournament:
 
+  /**
+    * The entry point for the Connect Four tournament application.
+    * It initializes tournament settings based on command-line arguments
+    * and prints the resulting league table to the standard output.
+    *
+    * @param args an array of strings, where the first element optionally defines
+    *             the number of games per pairing as an integer and the second element
+    *             optionally defines the random seed as a `Long`. Defaults to 6 games
+    *             per pairing and the current system time as the seed if not provided.
+    * @return Unit, as the result is printed to stdout.
+    */
   def main(args: Array[String]): Unit =
     val gamesPerPairing = args.headOption.flatMap(_.toIntOption).getOrElse(6)
-    println(run(gamesPerPairing = gamesPerPairing))
+    val seed = args.lift(1).flatMap(_.toLongOption).getOrElse(System.currentTimeMillis())
+    println(run(gamesPerPairing = gamesPerPairing, seed = seed))
 
   /**
     * Build and run the tournament, returning the league table as a String.
@@ -33,18 +46,18 @@ object Connect4Tournament:
     val rng = new Random(seed)
 
     val contestants = Seq(
-      Contestant("Random",         new RandomPlayer),
-      Contestant("Heuristic",      new HeuristicPlayer),
+      Contestant("Random", new RandomPlayer),
+      Contestant("Heuristic", new HeuristicPlayer),
       Contestant("AlphaBeta(d=4)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)),
       Contestant("AlphaBeta(d=6)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 6)),
-      Contestant("MCTS(i=200)",    MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)),
-      Contestant("MCTS(i=500)",    MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 500)),
+      Contestant("MCTS(i=200)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)),
+      Contestant("MCTS(i=500)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 500)),
     )
 
     val tournament = Tournament[Connect4, Connect4, Int, Boolean](
-      contestants     = contestants,
+      contestants = contestants,
       gamesPerPairing = gamesPerPairing,
-      random          = rng
+      random = rng
     )
 
     s"Connect Four Tournament ($gamesPerPairing games per pairing)\n\n${tournament.leagueTable}"

--- a/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4Tournament.scala
@@ -1,7 +1,7 @@
 package com.phasmidsoftware.gambit.examples.connect4
 
 import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
-import com.phasmidsoftware.gambit.game.{AlphaBetaPlayer, Contestant, MCTSPlayer, Tournament}
+import com.phasmidsoftware.gambit.game.{AlphaBetaPlayer, Contestant, GambitConfig, MCTSPlayer, Tournament}
 
 import scala.util.Random
 
@@ -9,50 +9,73 @@ import scala.util.Random
   * Runs a round-robin tournament between all Connect Four player types
   * and prints the league table to stdout.
   *
+  * Player parameters (depths, iteration counts, exploration constant) are
+  * read from `application.conf` via [[com.phasmidsoftware.gambit.game.GambitConfig]].
+  * Edit the config file to tune contestants without recompiling.
+  *
   * Players entered:
   *   - RandomPlayer
   *   - HeuristicPlayer  (one-ply greedy)
-  *   - AlphaBeta(d=4)   (minimax, depth 4)
-  *   - AlphaBeta(d=6)   (minimax, depth 6)
-  *   - MCTS(i=200)      (Monte Carlo, 200 iterations)
-  *   - MCTS(i=500)      (Monte Carlo, 500 iterations)
+  *   - AlphaBeta(d=d1)  (minimax, depth from config)
+  *   - AlphaBeta(d=d2)  (minimax, deeper depth from config)
+  *   - MCTS(i=i1)       (Monte Carlo, iteration count from config)
+  *   - MCTS(i=i2)       (Monte Carlo, higher iteration count from config)
   */
 object Connect4Tournament:
 
   /**
     * The entry point for the Connect Four tournament application.
-    * It initializes tournament settings based on command-line arguments
-    * and prints the resulting league table to the standard output.
+    * Command-line args override config defaults.
     *
-    * @param args an array of strings, where the first element optionally defines
-    *             the number of games per pairing as an integer and the second element
-    *             optionally defines the random seed as a `Long`. Defaults to 6 games
-    *             per pairing and the current system time as the seed if not provided.
-    * @return Unit, as the result is printed to stdout.
+    * @param args optional: args(0) = gamesPerPairing (Int), args(1) = seed (Long).
     */
   def main(args: Array[String]): Unit =
-    val gamesPerPairing = args.headOption.flatMap(_.toIntOption).getOrElse(6)
+    val gamesPerPairing = args.headOption.flatMap(_.toIntOption).getOrElse(GambitConfig.tournamentGamesPerPairing)
     val seed = args.lift(1).flatMap(_.toLongOption).getOrElse(System.currentTimeMillis())
     println(run(gamesPerPairing = gamesPerPairing, seed = seed))
 
   /**
     * Build and run the tournament, returning the league table as a String.
     *
-    * @param gamesPerPairing number of games each ordered pair plays (default 6).
-    * @param seed            random seed for reproducibility (default 42).
+    * Player parameters are read from [[GambitConfig]] (`application.conf`).
+    * Override by editing the config file -- no recompilation needed.
+    *
+    * @param gamesPerPairing number of games each ordered pair plays
+    *                        (default from config: `gambit.tournament.gamesPerPairing`).
+    *
+    * @param seed            random seed; default is `System.currentTimeMillis()`.
     * @return the formatted league table.
     */
-  def run(gamesPerPairing: Int = 6, seed: Long = 42L): String =
+  def run(
+           gamesPerPairing: Int = GambitConfig.tournamentGamesPerPairing,
+           seed: Long = System.currentTimeMillis()
+         ): String =
+    val announcement = s"Connect Four Tournament ($gamesPerPairing games per pairing)"
+    val marquee = "*" * announcement.length
+    println(marquee)
+    println(announcement)
+    println(marquee)
+
     val rng = new Random(seed)
+    val d1 = GambitConfig.alphaBetaDepth1
+    val d2 = GambitConfig.alphaBetaDepth2
+    val i1 = GambitConfig.mctsIterations1
+    val i2 = GambitConfig.mctsIterations2
+    val c = GambitConfig.mctsExplorationConstant
+
+    println(s"depth1=$d1, depth2=$d2, iterations1=$i1, iterations2=$i2, explorationConstant=$c")
 
     val contestants = Seq(
       Contestant("Random", new RandomPlayer),
       Contestant("Heuristic", new HeuristicPlayer),
-      Contestant("AlphaBeta(d=4)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)),
-      Contestant("AlphaBeta(d=6)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 6)),
-      Contestant("MCTS(i=200)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)),
-      Contestant("MCTS(i=500)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 500)),
+      Contestant(s"AlphaBeta(d=$d1)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = d1)),
+      Contestant(s"AlphaBeta(d=$d2)", AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = d2)),
+      Contestant(s"MCTS(i=$i1)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = i1, explorationConstant = c)),
+      Contestant(s"MCTS(i=$i2)", MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = i2, explorationConstant = c)),
     )
+
+    println(s"Contestants: ${contestants.map(_.name).mkString(", ")}")
+    System.out.flush()
 
     val tournament = Tournament[Connect4, Connect4, Int, Boolean](
       contestants = contestants,
@@ -60,4 +83,4 @@ object Connect4Tournament:
       random = rng
     )
 
-    s"Connect Four Tournament ($gamesPerPairing games per pairing)\n\n${tournament.leagueTable}"
+    s"\n${tournament.leagueTable}"

--- a/src/main/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayer.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayer.scala
@@ -1,0 +1,140 @@
+package com.phasmidsoftware.gambit.game
+
+import scala.util.{Random, boundary}
+import scala.util.boundary.break
+
+/**
+  * A generic alpha-beta pruning player.
+  *
+  * Implements minimax search with alpha-beta pruning to a configurable depth.
+  * Alpha-beta pruning eliminates branches that cannot affect the final decision,
+  * reducing the effective branching factor from b to approximately √b in the
+  * best case — effectively doubling the achievable search depth for the same
+  * computation compared to plain minimax.
+  *
+  * == Heuristic Convention ==
+  *
+  * `State.heuristic(s)` is positive when the player who just moved to reach `s`
+  * is doing well. This is consistent with the convention used throughout Gambit.
+  * At leaf nodes (terminal or depth limit reached), the raw heuristic is returned.
+  * The maximizing/minimizing logic correctly accounts for this convention.
+  *
+  * == Move Ordering ==
+  *
+  * Moves are ordered by heuristic before recursing — highest first for the
+  * maximizing player, lowest first for the minimizing player. This shallow
+  * search ordering maximises the probability of early pruning, approaching
+  * the theoretical best-case performance of alpha-beta.
+  *
+  * == Mutable State ==
+  *
+  * Alpha and beta bounds are tracked with mutable variables, and `boundary`/`break`
+  * is used for early termination on a prune. This is intentional: alpha-beta
+  * pruning is fundamentally about early exit based on accumulated bounds, and
+  * fighting that with purely functional constructs would sacrifice both clarity
+  * and performance. Mutable state is appropriate here for the same reason it is
+  * appropriate in high-performance sorting algorithms.
+  *
+  * @param me    this player's identity.
+  * @param depth search depth in plies (half-moves). Default 6.
+  *              Higher values give stronger play at the cost of
+  *              exponentially more computation.
+  *
+  * @param state implicit State[P, S] for goal detection and heuristic.
+  * @param game  implicit Game[S, M, Pl] for move generation and application.
+  * @tparam P  the proto-state type.
+  * @tparam S  the state type.
+  * @tparam M  the move type.
+  * @tparam Pl the player identity type.
+  */
+class AlphaBetaPlayer[P, S, M, Pl](
+                                    me: Pl,
+                                    depth: Int = 6
+                                  )(using state: State[P, S], game: Game[S, M, Pl])
+  extends Player[S, M, Pl]:
+
+  override def chooseMove(s: S, random: Random): Option[M] =
+    if state.isGoal(s).isDefined then None
+    else
+      val moves = game.moves(s)
+      if moves.isEmpty then None
+      else
+        val currentPl = game.currentPlayer(s)(using state)
+        val maximizing = currentPl == me
+        // Evaluate each move and pick the best.
+        val scored = moves.map { m =>
+          val next = game.applyMove(s, m, currentPl)
+          m -> alphaBeta(next, depth - 1, -Double.MaxValue, Double.MaxValue, !maximizing)
+        }
+        val best = if maximizing then scored.maxBy(_._2) else scored.minBy(_._2)
+        Some(best._1)
+
+  // ---------------------------------------------------------------------------
+  // Alpha-beta search
+  // ---------------------------------------------------------------------------
+
+  /**
+    * Recursive alpha-beta search.
+    *
+    * Returns the minimax value of state `s` from the perspective of `me`,
+    * searching to the given depth with alpha-beta pruning.
+    *
+    * @param s          the state to evaluate.
+    * @param depth      remaining search depth (0 = evaluate immediately).
+    * @param alpha      best score the maximizing player is guaranteed so far.
+    * @param beta       best score the minimizing player is guaranteed so far.
+    * @param maximizing true if the current player is maximizing (i.e. is `me`).
+    * @return the minimax value of `s`.
+    */
+  private def alphaBeta(s: S, depth: Int, alpha: Double, beta: Double, maximizing: Boolean): Double =
+    // heuristic(s) is from the perspective of the player who just moved INTO s.
+    // alphaBeta returns a value from me's perspective (positive = good for me).
+    // When the maximizing player (me) just moved: heuristic sign is correct.
+    // When the minimizing player just moved: heuristic must be negated.
+    def leafValue: Double = if maximizing then -state.heuristic(s) else state.heuristic(s)
+
+    state.isGoal(s) match
+      case Some(_) => leafValue
+      case None if depth == 0 => leafValue
+      case None =>
+        val currentPl = game.currentPlayer(s)(using state)
+        val moves = orderedMoves(s, currentPl, maximizing)
+        if maximizing then
+          var a = alpha
+          var best = -Double.MaxValue
+          boundary:
+            moves.foreach { (m, next) =>
+              best = best.max(alphaBeta(next, depth - 1, a, beta, false))
+              a = a.max(best)
+              if a >= beta then break(best) // prune: minimizer won't allow this
+            }
+          best
+        else
+          var b = beta
+          var best = Double.MaxValue
+          boundary:
+            moves.foreach { (m, next) =>
+              best = best.min(alphaBeta(next, depth - 1, alpha, b, true))
+              b = b.min(best)
+              if alpha >= b then break(best) // prune: maximizer won't allow this
+            }
+          best
+
+  /**
+    * Generate and order successor (move, state) pairs for move ordering.
+    *
+    * For the maximizing player, high-heuristic successors are tried first —
+    * they are most likely to raise alpha quickly and trigger pruning.
+    * For the minimizing player, low-heuristic successors are tried first.
+    *
+    * @param s          the current state.
+    * @param currentPl  the player to move.
+    * @param maximizing true if the current player is maximizing.
+    * @return ordered sequence of (move, successor state) pairs.
+    */
+  private def orderedMoves(s: S, currentPl: Pl, maximizing: Boolean): Seq[(M, S)] =
+    val successors = game.moves(s).map { m =>
+      m -> game.applyMove(s, m, currentPl)
+    }
+    if maximizing then successors.sortBy((_, next) => -state.heuristic(next))
+    else successors.sortBy((_, next) => state.heuristic(next))

--- a/src/main/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayer.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayer.scala
@@ -5,6 +5,7 @@ import scala.util.boundary.break
 
 /**
   * A generic alpha-beta pruning player.
+  * For more information, see [[https://en.wikipedia.org/wiki/Alpha–beta_pruning]]
   *
   * Implements minimax search with alpha-beta pruning to a configurable depth.
   * Alpha-beta pruning eliminates branches that cannot affect the final decision,

--- a/src/main/scala/com/phasmidsoftware/gambit/game/GambitConfig.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/game/GambitConfig.scala
@@ -1,0 +1,44 @@
+package com.phasmidsoftware.gambit.game
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+/**
+  * Loads and exposes typed configuration values for the Gambit framework.
+  *
+  * Configuration is read from `application.conf` on the classpath (standard
+  * Typesafe Config behaviour). All values have hard-coded fallbacks so the
+  * application runs correctly even if no config file is present.
+  *
+  * == HOCON structure ==
+  * {{{
+  * gambit {
+  *   tournament.gamesPerPairing = 6
+  *   alphaBeta.depth1           = 4
+  *   alphaBeta.depth2           = 6
+  *   mcts.iterations1           = 200
+  *   mcts.iterations2           = 500
+  *   mcts.explorationConstant   = 1.4142135623730951
+  * }
+  * }}}
+  */
+object GambitConfig:
+
+  private val config: Config = ConfigFactory.load().getConfig("gambit")
+
+  /** Default number of games per pairing in a tournament. */
+  val tournamentGamesPerPairing: Int = config.getInt("tournament.gamesPerPairing")
+
+  /** Depth for the shallower AlphaBeta contestant. */
+  val alphaBetaDepth1: Int = config.getInt("alphaBeta.depth1")
+
+  /** Depth for the deeper AlphaBeta contestant. */
+  val alphaBetaDepth2: Int = config.getInt("alphaBeta.depth2")
+
+  /** Iteration count for the lighter MCTS contestant. */
+  val mctsIterations1: Int = config.getInt("mcts.iterations1")
+
+  /** Iteration count for the heavier MCTS contestant. */
+  val mctsIterations2: Int = config.getInt("mcts.iterations2")
+
+  /** UCB1 exploration constant C for MCTS (default √2). */
+  val mctsExplorationConstant: Double = config.getDouble("mcts.explorationConstant")

--- a/src/main/scala/com/phasmidsoftware/gambit/game/MCTSPlayer.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/game/MCTSPlayer.scala
@@ -7,17 +7,20 @@ import scala.util.Random
   * A generic Monte Carlo Tree Search player.
   *
   * Implements the standard four-phase MCTS loop:
-  *   1. Selection   — walk the tree by UCB1 (Upper Confidence Bound) until an unexpanded node is found.
-  *   2. Expansion   — add one new child for an untried move.
-  *   3. Simulation  — play randomly to a terminal state (rollout).
-  *   4. Backprop    — update visit/win counts along the path to root.
+  *   1. Selection   -- walk the tree by UCB1 (Upper Confidence Bound) until an unexpanded node is found.
+  *   2. Expansion   -- add one new child for an untried move.
+  *   3. Simulation  -- play randomly to a terminal state (rollout).
+  *   4. Backprop    -- update visit/win counts along the path to root.
   *
-  * The search tree is rebuilt from scratch on each call to `chooseMove`.
+  * The search tree is retained between calls to `chooseMove`. After each move
+  * the subtree rooted at the chosen child becomes the new root, carrying forward
+  * all accumulated visit and win counts. If the opponent plays an unexplored line
+  * the retained tree cannot be advanced and a fresh root is created instead.
+  *
+  * Tree matching uses `==` on the state type `S`; callers must ensure `S` has
+  * meaningful equality (satisfied by `case class` and `case object`).
   *
   * == Future upgrades ==
-  *
-  * - **Tree reuse**: retain the subtree rooted at the chosen move between
-  *   calls, avoiding redundant re-exploration of already-visited states.
   *
   * - **Actor-based parallelism**: move the mutable tree into an Akka/Pekko
   *   actor. Multiple rollout worker actors could then submit simulation
@@ -29,7 +32,7 @@ import scala.util.Random
   *
   * @param me                  this player's identity.
   * @param iterations          number of MCTS iterations per move (default 1000).
-  * @param explorationConstant UCB1 exploration parameter C (default √2).
+  * @param explorationConstant UCB1 exploration parameter C (default sqrt(2)).
   * @param state               implicit State[P, S] for goal detection.
   * @param game                implicit Game[S, M, Pl] for move application.
   * @tparam P  the proto-state type.
@@ -46,23 +49,59 @@ class MCTSPlayer[P, S, M, Pl](
 
   private type Triple = (MCTSNode[S, M, Pl], List[MCTSNode[S, M, Pl]], Pl)
 
+  /**
+    * The retained search tree from the previous call to `chooseMove`.
+    * None on the first call or after a cache miss (opponent played an
+    * unexplored line).
+    */
+  private var retainedRoot: Option[MCTSNode[S, M, Pl]] = None
+
+  override def gameOver(result: GameResult[Pl], me: Pl): Unit =
+    retainedRoot = None
+
   override def chooseMove(s: S, random: Random): Option[M] =
     if state.isGoal(s).isDefined then None
     else
-      val root = MCTSNode.root[S, M, Pl](s, game.moves(s).toList)
-      // game.currentPlayer(s) is the player about to move from s —
+      // Advance the retained tree to match the incoming state, or start fresh.
+      val root = advanceTree(s)
+      // game.currentPlayer(s) is the player about to move from s --
       // i.e. the player who will make the first move in the search tree.
       val rootPlayer = game.currentPlayer(s)(using state)
       for _ <- 1 to iterations do iterate(root, rootPlayer, random)
       // Most visited child is the most robust choice.
-      root.children.maxByOption(_.visits).flatMap(_.move)
+      val bestChild = root.children.maxByOption(_.visits)
+      // Retain the chosen subtree for the next call.
+      retainedRoot = bestChild
+      bestChild.flatMap(_.move)
+
+  /**
+    * Try to advance the retained tree to the node matching state `s`.
+    *
+    * `retainedRoot` is the child node we chose last turn (our move already
+    * applied). The opponent has since replied; we look for their move among
+    * that node's children. If found we reuse the subtree, preserving all
+    * accumulated visits and wins. If not found (opponent played an unexplored
+    * line, or this is the first call) we start fresh.
+    *
+    * @param s the current game state.
+    * @return the root node to use for this search.
+    */
+  private def advanceTree(s: S): MCTSNode[S, M, Pl] =
+    retainedRoot match
+      case None => MCTSNode.root(s, game.moves(s).toList)
+      case Some(prev) =>
+        // prev is the child we chose last turn (our move applied).
+        // The opponent has since replied; look for their move among prev's children.
+        prev.children.find(_.state == s) match
+          case Some(node) => node // cache hit: reuse the explored subtree
+          case None => MCTSNode.root(s, game.moves(s).toList) // cache miss: fresh tree
 
   // ---------------------------------------------------------------------------
   // MCTS phases
   // ---------------------------------------------------------------------------
 
   /**
-    * One full MCTS iteration: selection → expansion → simulation → backprop.
+    * One full MCTS iteration: selection -> expansion -> simulation -> backprop.
     *
     * @param root       the root of the search tree.
     * @param rootPlayer the player to move at the root.
@@ -173,7 +212,7 @@ class MCTSPlayer[P, S, M, Pl](
   * Children are added during expansion.
   * untriedMoves shrinks as children are expanded.
   *
-  * No parent reference — backpropagation uses an explicit path stack
+  * No parent reference -- backpropagation uses an explicit path stack
   * accumulated during selection, avoiding circular references and the
   * GC/equality issues that back-references cause in tree structures.
   *
@@ -183,7 +222,6 @@ class MCTSPlayer[P, S, M, Pl](
   * @param visits       number of times this node has been visited.
   * @param wins         cumulative score from simulations through this node,
   *                     from the perspective of `movedBy`.
-  *
   * @param children     expanded child nodes.
   * @param untriedMoves moves not yet expanded into children.
   * @tparam S  the state type.
@@ -207,7 +245,7 @@ class MCTSNode[S, M, Pl](
   def isFullyExpanded: Boolean = untriedMoves.isEmpty
 
   /**
-    * Determines if this node is a leaf node within the MCTS search tree.
+    * Determines if this node is a leaf node within the MCTS search tree (no children yet).
     * A leaf node is characterized by having no child nodes.
     *
     * @return true if this node has no children, indicating it is a leaf node; false otherwise.
@@ -219,41 +257,18 @@ class MCTSNode[S, M, Pl](
       s"children=${children.size}, untried=${untriedMoves.size})"
 
 /**
-  * Companion object for the `MCTSNode` class, providing factory methods to
-  * create root and child nodes in a Monte Carlo Tree Search (MCTS) search tree.
+  * Companion object for `MCTSNode`, providing factory methods.
   */
 object MCTSNode:
   /**
-    * Creates the root node of a Monte Carlo Tree Search (MCTS) tree.
-    *
-    * The root node represents the initial state of the game and contains
-    * all the possible moves for the starting player. It has no parent, no
-    * associated move, and no player who moved to generate it.
-    *
-    * @param state the initial game state.
-    * @param moves the list of moves available from the initial state.
-    * @tparam S  the type representing the game state.
-    * @tparam M  the type representing a move in the game.
-    * @tparam Pl the type representing a player in the game.
-    * @return an `MCTSNode` representing the root of the MCTS tree.
+    * Creates the root node of an MCTS tree.
+    * No parent, no associated move, no player who moved to generate it.
     */
   def root[S, M, Pl](state: S, moves: List[M]): MCTSNode[S, M, Pl] =
     new MCTSNode(state, None, None, 0, 0.0, mutable.ListBuffer.empty, moves)
 
   /**
-    * Creates a child node in a Monte Carlo Tree Search (MCTS) tree.
-    *
-    * A child node is derived from a given game state, move, and the player who made that move.
-    * It also holds the list of untried moves available from the resulting state.
-    *
-    * @param state   the game state at this node.
-    * @param move    the move that led to this state.
-    * @param movedBy the player who made the move.
-    * @param moves   the list of untried moves available from this state.
-    * @tparam S  the type representing the game state.
-    * @tparam M  the type representing a move in the game.
-    * @tparam Pl the type representing a player in the game.
-    * @return an `MCTSNode` representing the child node with the specified parameters.
+    * Creates a child node derived from a given state, move, and the player who made it.
     */
   def child[S, M, Pl](state: S, move: M, movedBy: Pl, moves: List[M]): MCTSNode[S, M, Pl] =
     new MCTSNode(state, Some(move), Some(movedBy), 0, 0.0, mutable.ListBuffer.empty, moves)

--- a/src/main/scala/com/phasmidsoftware/gambit/game/MCTSPlayer.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/game/MCTSPlayer.scala
@@ -5,6 +5,8 @@ import scala.util.Random
 
 /**
   * A generic Monte Carlo Tree Search player.
+  * For more information about MCTS, see
+  * [[https://en.wikipedia.org/wiki/Monte_Carlo_tree_search]]
   *
   * Implements the standard four-phase MCTS loop:
   *   1. Selection   -- walk the tree by UCB1 (Upper Confidence Bound) until an unexpanded node is found.

--- a/src/main/scala/com/phasmidsoftware/gambit/game/Tournament.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/game/Tournament.scala
@@ -81,7 +81,7 @@ class Tournament[P, S, M, Pl](
     */
   def standings: Seq[(String, Int, Int, Int, Int, Int, Int)] =
     val totals = scala.collection.mutable.Map(
-      contestants.map(_.name -> TournamentRecord()): _*
+      contestants.map(_.name -> TournamentRecord()) *
     )
     // Every ordered pair (i, j) with i != j: contestant i plays as first player.
     for

--- a/src/main/scala/com/phasmidsoftware/gambit/game/Tournament.scala
+++ b/src/main/scala/com/phasmidsoftware/gambit/game/Tournament.scala
@@ -1,0 +1,129 @@
+package com.phasmidsoftware.gambit.game
+
+import scala.util.Random
+
+/**
+  * A named contestant in a tournament.
+  *
+  * Wraps a `Player` with a display name so the league table can identify
+  * each entry independently of the Boolean player-identity used internally
+  * by two-player `GameRunner`.
+  *
+  * @param name   display name for the league table.
+  * @param player the underlying player.
+  * @tparam S  the state type.
+  * @tparam M  the move type.
+  * @tparam Pl the player identity type.
+  */
+case class Contestant[S, M, Pl](name: String, player: Player[S, M, Pl])
+
+/**
+  * A round-robin tournament for two-player zero-sum games.
+  *
+  * Every pair of contestants plays `gamesPerPairing` games with each
+  * contestant taking the first-player role in half the games, so neither
+  * side has a systematic first-move advantage in the overall standings.
+  *
+  * == Scoring ==
+  * Standard football (soccer) 3-1-0 scoring:
+  * Win  = 3 points
+  * Draw = 1 point
+  * Loss = 0 points
+  *
+  * Ties in the table are broken by goal difference (wins minus losses),
+  * then by total wins.
+  *
+  * == Usage ==
+  * {{{
+  *   val t = Tournament(contestants, gamesPerPairing = 10, random = new Random(42L))
+  *   println(t.leagueTable)
+  * }}}
+  *
+  * @param contestants     the players to enter in the tournament.
+  * @param gamesPerPairing number of games each ordered pair plays (A-as-first
+  *                        vs B-as-second). Each unordered pair therefore plays
+  *                        2 * gamesPerPairing games in total.
+  *
+  * @param random          random source passed to each GameRunner.
+  * @param state           implicit State[P, S].
+  * @param game            implicit Game[S, M, Pl].
+  * @tparam P  the proto-state type.
+  * @tparam S  the state type.
+  * @tparam M  the move type.
+  * @tparam Pl the player identity type.
+  */
+class Tournament[P, S, M, Pl](
+                               contestants: Seq[Contestant[S, M, Pl]],
+                               gamesPerPairing: Int = 10,
+                               random: Random = new Random(42L)
+                             )(using state: State[P, S], game: Game[S, M, Pl]):
+
+  /**
+    * Run the full round-robin and return a formatted league table string.
+    *
+    * Each row shows: rank, name, games played, wins, draws, losses, points.
+    * Rows are sorted by points desc, then goal difference desc, then wins desc.
+    */
+  def leagueTable: String =
+    val rows = standings
+    val nameWidth = (contestants.map(_.name.length) :+ "Player".length).max
+    val header = formatRow("Player", "P", "W", "D", "L", "GD", "Pts", nameWidth)
+    val separator = "-" * header.length
+    val body = rows.zipWithIndex.map { case ((name, p, w, d, l, gd, pts), i) =>
+      s"${i + 1}. " + formatRow(name, p.toString, w.toString, d.toString, l.toString,
+        (if gd >= 0 then "+" else "") + gd, pts.toString, nameWidth)
+    }
+    (Seq(header, separator) ++ body).mkString("\n")
+
+  /**
+    * Run all pairings and return the sorted standings.
+    * Each entry is (name, played, wins, draws, losses, goalDiff, points).
+    */
+  def standings: Seq[(String, Int, Int, Int, Int, Int, Int)] =
+    val totals = scala.collection.mutable.Map(
+      contestants.map(_.name -> TournamentRecord()): _*
+    )
+    // Every ordered pair (i, j) with i != j: contestant i plays as first player.
+    for
+      i <- contestants.indices
+      j <- contestants.indices
+      if i != j
+    do
+      val first = contestants(i)
+      val second = contestants(j)
+      val runner = new GameRunner[P, S, M, Pl](
+        playerMap = Map(
+          game.startingPlayer -> first.player,
+          game.players.find(_ != game.startingPlayer).get -> second.player
+        ),
+        random = random
+      )
+      val results = runner.playGames(gamesPerPairing)
+      // Accumulate from first player's perspective (identity = startingPlayer = true).
+      val fp = game.startingPlayer
+      val sp = game.players.find(_ != game.startingPlayer).get
+      totals(first.name) = totals(first.name).add(results.winsFor(fp), results.drawsFor(fp), results.lossesFor(fp))
+      totals(second.name) = totals(second.name).add(results.winsFor(sp), results.drawsFor(sp), results.lossesFor(sp))
+
+    totals.toSeq
+      .map { case (name, r) => (name, r.played, r.wins, r.draws, r.losses, r.wins - r.losses, r.points) }
+      .sortBy { case (_, _, w, _, l, gd, pts) => (-pts, -(w - l), -w) }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private def formatRow(name: String, p: String, w: String, d: String,
+                        l: String, gd: String, pts: String, nameWidth: Int): String =
+    s"%-${nameWidth}s  %4s  %4s  %4s  %4s  %4s  %4s".format(name, p, w, d, l, gd, pts)
+
+  /**
+    * Mutable accumulator for one contestant's running totals.
+    */
+  private case class TournamentRecord(
+                                       played: Int = 0, wins: Int = 0, draws: Int = 0, losses: Int = 0
+                                     ):
+    def points: Int = wins * 3 + draws
+
+    def add(w: Int, d: Int, l: Int): TournamentRecord =
+      TournamentRecord(played + w + d + l, wins + w, draws + d, losses + l)

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=latest/api/">
+</head>
+<body>
+<a href="latest/api/">Redirecting to API docs...</a>
+</body>
+</html>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -35,7 +35,7 @@
         <appender-ref ref="FILE-ROLLING"/>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ASYNC"/>
     </root>

--- a/src/test/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4DemoSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4DemoSpec.scala
@@ -4,6 +4,7 @@ import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
 import com.phasmidsoftware.gambit.game.MCTSPlayer
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
+import org.scalatest.tagobjects.Slow
 
 import scala.util.Random
 
@@ -53,19 +54,19 @@ class Connect4DemoSpec extends AnyFlatSpec with should.Matchers {
   // MCTS player
   // ---------------------------------------------------------------------------
 
-  it should "return a defined result for MCTS vs Random" in {
+  it should "return a defined result for MCTS vs Random" taggedAs Slow in {
     val mcts = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)
     val result = playConnect4Demo(mcts, "MCTS", new RandomPlayer, "Random", rng)
     result shouldBe defined
   }
 
-  it should "return a defined result for MCTS vs Heuristic" in {
+  it should "return a defined result for MCTS vs Heuristic" taggedAs Slow in {
     val mctsX = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)
     val result = playConnect4Demo(mctsX, "MCTS", new HeuristicPlayer, "Heuristic", rng)
     result shouldBe defined
   }
 
-  it should "return a defined result for MCTS vs MCTS" in {
+  it should "return a defined result for MCTS vs MCTS" taggedAs Slow in {
     val mctsX = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)
     val mctsO = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = false, iterations = 200)
     val result = playConnect4Demo(mctsX, "MCTS", mctsO, "MCTS", rng)

--- a/src/test/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4GameSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/examples/connect4/Connect4GameSpec.scala
@@ -3,6 +3,7 @@ package com.phasmidsoftware.gambit.examples.connect4
 import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
+import org.scalatest.tagobjects.Slow
 
 import scala.util.Random
 
@@ -112,14 +113,14 @@ class Connect4GameSpec extends AnyFlatSpec with should.Matchers {
     result(false) should (be(-1) or be(0) or be(1))
   }
 
-  it should "accumulate correct totals over multiple games" in {
+  it should "accumulate correct totals over multiple games" taggedAs Slow in {
     val runner = Connect4GameRunner(new RandomPlayer, new RandomPlayer, new Random(3L))
     val stats = runner.playGames(100)
     stats.total shouldBe 100
     stats.winsFor(true) + stats.winsFor(false) + stats.drawsFor(true) shouldBe 100
   }
 
-  it should "never produce a result where both players win" in {
+  it should "never produce a result where both players win" taggedAs Slow in {
     val runner = Connect4GameRunner(new RandomPlayer, new RandomPlayer, new Random(4L))
     val stats = runner.playGames(50)
     stats.results.foreach { result =>
@@ -133,13 +134,13 @@ class Connect4GameSpec extends AnyFlatSpec with should.Matchers {
 
   behavior of "HeuristicPlayer vs RandomPlayer"
 
-  it should "win more than it loses as X against a random player" in {
+  it should "win more than it loses as X against a random player" taggedAs Slow in {
     val runner = Connect4GameRunner(new HeuristicPlayer, new RandomPlayer, new Random(5L))
     val stats = runner.playGames(50)
     stats.winsFor(true) should be > stats.lossesFor(true)
   }
 
-  it should "win more than it loses as O against a random player" in {
+  it should "win more than it loses as O against a random player" taggedAs Slow in {
     val runner = Connect4GameRunner(new RandomPlayer, new HeuristicPlayer, new Random(6L))
     val stats = runner.playGames(50)
     stats.winsFor(false) should be > stats.lossesFor(false)
@@ -156,7 +157,7 @@ class Connect4GameSpec extends AnyFlatSpec with should.Matchers {
     noException should be thrownBy runner.playGame()
   }
 
-  it should "always produce a valid result" in {
+  it should "always produce a valid result" taggedAs Slow in {
     val runner = Connect4GameRunner(new HeuristicPlayer, new HeuristicPlayer, new Random(8L))
     val stats = runner.playGames(10)
     stats.total shouldBe 10

--- a/src/test/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayerSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayerSpec.scala
@@ -1,0 +1,163 @@
+package com.phasmidsoftware.gambit.game
+
+import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
+import com.phasmidsoftware.gambit.examples.connect4.{Connect4, Connect4GameRunner, Connect4State, connect4Game, HeuristicPlayer as C4HeuristicPlayer, RandomPlayer as C4RandomPlayer}
+import com.phasmidsoftware.gambit.examples.tictactoe.TicTacToe.TicTacToeState$
+import com.phasmidsoftware.gambit.examples.tictactoe.{Board, PerfectPlayer, TicTacToe, TicTacToeGameRunner, tictactoeGame, RandomPlayer as TTTRandomPlayer}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import org.scalatest.tagobjects.Slow
+
+import scala.util.Random
+
+class AlphaBetaPlayerSpec extends AnyFlatSpec with should.Matchers {
+
+  // ---------------------------------------------------------------------------
+  // TicTacToe — AlphaBetaPlayer
+  // ---------------------------------------------------------------------------
+
+  behavior of "AlphaBetaPlayer on TicTacToe"
+
+  it should "choose a valid move from the starting position" in {
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 4)
+    val move = ab.chooseMove(TicTacToe.start, new Random(1L))
+    move shouldBe defined
+    move.get should (be >= 0 and be <= 8)
+  }
+
+  it should "return None for a terminal position" in {
+    val xWin = TicTacToe.parse("XXX- 0 -0  ").get
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 4)
+    ab.chooseMove(xWin, new Random(1L)) shouldBe None
+  }
+
+  it should "take a winning move for X when available" in {
+    // X at (0,0),(0,1); O at (1,0),(1,1) — X to move, wins at (0,2).
+    val ttt = TicTacToe.parse("XX -00 -   ").get
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 4)
+    val move = ab.chooseMove(ttt, new Random(1L))
+    move shouldBe defined
+    val row = move.get / TicTacToe.size
+    val col = move.get % TicTacToe.size
+    val next = TicTacToeState$.construct(ttt.playX(row, col))
+    TicTacToeState$.isGoal(next) shouldBe Some(true)
+  }
+
+  it should "block O from winning" in {
+    // O at (0,0),(0,1); X at (1,1),(2,2) — X must block at (0,2).
+    val ttt = TicTacToe.parse("00 -X  -  X").get
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 4)
+    val move = ab.chooseMove(ttt, new Random(1L))
+    move shouldBe defined
+    val row = move.get / TicTacToe.size
+    val col = move.get % TicTacToe.size
+    val next = TicTacToeState$.construct(ttt.playX(row, col))
+    val oResponses = TicTacToeState$.getStates(next)
+    val oWins = oResponses.filter(s => TicTacToeState$.isGoal(s).contains(true) && !TicTacToeState$.isWin(s))
+    oWins shouldBe empty
+  }
+
+  it should "never lose as X against a random player" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 6)
+    val runner = TicTacToeGameRunner(ab, new TTTRandomPlayer, new Random(1L))
+    val stats = runner.playGames(20)
+    stats.winsFor(false) shouldBe 0
+  }
+
+  it should "never lose as O against a random player" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = false, depth = 6)
+    val runner = TicTacToeGameRunner(new TTTRandomPlayer, ab, new Random(2L))
+    val stats = runner.playGames(20)
+    stats.winsFor(true) shouldBe 0
+  }
+
+  it should "always draw against PerfectPlayer" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 6)
+    val runner = TicTacToeGameRunner(ab, new PerfectPlayer, new Random(3L))
+    val stats = runner.playGames(10)
+    stats.winsFor(false) shouldBe 0 // AlphaBeta should never lose
+  }
+
+  it should "always draw against itself" taggedAs Slow in {
+    val abX = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 6)
+    val abO = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = false, depth = 6)
+    val runner = TicTacToeGameRunner(abX, abO, new Random(4L))
+    val stats = runner.playGames(5)
+    stats.winsFor(true) shouldBe 0
+    stats.winsFor(false) shouldBe 0
+    stats.drawsFor(true) shouldBe 5
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connect Four — AlphaBetaPlayer
+  // ---------------------------------------------------------------------------
+
+  behavior of "AlphaBetaPlayer on Connect4"
+
+  it should "choose a valid column from the starting position" in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)
+    val move = ab.chooseMove(Connect4.start, new Random(1L))
+    move shouldBe defined
+    move.get should (be >= 0 and be <= Connect4.cols - 1)
+    Connect4.start.open should contain(move.get)
+  }
+
+  it should "return None for a terminal Connect4 position" in {
+    val win = Connect4.start
+      .play(0, isX = true).play(4, isX = false)
+      .play(1, isX = true).play(4, isX = false)
+      .play(2, isX = true).play(4, isX = false)
+      .play(3, isX = true)
+    Connect4State.isGoal(win) shouldBe Some(true)
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)
+    ab.chooseMove(win, new Random(1L)) shouldBe None
+  }
+
+  it should "take a winning move when available" in {
+    // X has 3 in a row at cols 0,1,2 — wins at col 3.
+    val almostWin = Connect4.start
+      .play(0, isX = true).play(6, isX = false)
+      .play(1, isX = true).play(6, isX = false)
+      .play(2, isX = true).play(6, isX = false)
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)
+    val move = ab.chooseMove(almostWin, new Random(1L))
+    move shouldBe Some(3)
+  }
+
+  it should "prefer the centre column from the starting position" in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)
+    val move = ab.chooseMove(Connect4.start, new Random(1L))
+    move shouldBe Some(3)
+  }
+
+  it should "win more than it loses as X against a random player" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)
+    val runner = Connect4GameRunner(ab, new C4RandomPlayer, new Random(5L))
+    val stats = runner.playGames(20)
+    stats.winsFor(true) should be > stats.lossesFor(true)
+  }
+
+  it should "win more than it loses as O against a random player" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = false, depth = 4)
+    val runner = Connect4GameRunner(new C4RandomPlayer, ab, new Random(6L))
+    val stats = runner.playGames(20)
+    stats.winsFor(false) should be > stats.lossesFor(false)
+  }
+
+  it should "be competitive against HeuristicPlayer" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)
+    val heuristic = new C4HeuristicPlayer
+    val runner = Connect4GameRunner(ab, heuristic, new Random(7L))
+    val stats = runner.playGames(10)
+    // AlphaBeta with depth 4 should outperform one-ply heuristic.
+    stats.winsFor(true) should be >= stats.winsFor(false)
+  }
+
+  it should "be stronger than HeuristicPlayer with greater depth" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 6)
+    val heuristic = new C4HeuristicPlayer
+    val runner = Connect4GameRunner(ab, heuristic, new Random(8L))
+    val stats = runner.playGames(10)
+    stats.winsFor(true) should be > stats.lossesFor(true)
+  }
+}

--- a/src/test/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayerSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/game/AlphaBetaPlayerSpec.scala
@@ -57,13 +57,6 @@ class AlphaBetaPlayerSpec extends AnyFlatSpec with should.Matchers {
     oWins shouldBe empty
   }
 
-  it should "never lose as X against a random player" taggedAs Slow in {
-    val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = true, depth = 6)
-    val runner = TicTacToeGameRunner(ab, new TTTRandomPlayer, new Random(1L))
-    val stats = runner.playGames(20)
-    stats.winsFor(false) shouldBe 0
-  }
-
   it should "never lose as O against a random player" taggedAs Slow in {
     val ab = AlphaBetaPlayer[Board, TicTacToe, Int, Boolean](me = false, depth = 6)
     val runner = TicTacToeGameRunner(new TTTRandomPlayer, ab, new Random(2L))
@@ -151,13 +144,5 @@ class AlphaBetaPlayerSpec extends AnyFlatSpec with should.Matchers {
     val stats = runner.playGames(10)
     // AlphaBeta with depth 4 should outperform one-ply heuristic.
     stats.winsFor(true) should be >= stats.winsFor(false)
-  }
-
-  it should "be stronger than HeuristicPlayer with greater depth" taggedAs Slow in {
-    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 6)
-    val heuristic = new C4HeuristicPlayer
-    val runner = Connect4GameRunner(ab, heuristic, new Random(8L))
-    val stats = runner.playGames(10)
-    stats.winsFor(true) should be > stats.lossesFor(true)
   }
 }

--- a/src/test/scala/com/phasmidsoftware/gambit/game/MCTSPlayerSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/game/MCTSPlayerSpec.scala
@@ -33,21 +33,21 @@ class MCTSPlayerSpec extends AnyFlatSpec with should.Matchers {
     mcts.chooseMove(xWin, new Random(1L)) shouldBe None
   }
 
-  it should "never lose as X against a random player" taggedAs Slow in {
+  it should "never lose as X against a random player" in {
     val mcts   = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = true, iterations = 300)
     val runner = TicTacToeGameRunner(mcts, new TTTRandomPlayer, new Random(1L))
     val stats  = runner.playGames(50)
     stats.winsFor(false) shouldBe 0
   }
 
-  it should "never lose as O against a random player" taggedAs Slow in {
+  it should "never lose as O against a random player" in {
     val mcts   = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = false, iterations = 300)
     val runner = TicTacToeGameRunner(new TTTRandomPlayer, mcts, new Random(2L))
     val stats  = runner.playGames(50)
     stats.winsFor(true) shouldBe 0
   }
 
-  it should "draw most games against itself" taggedAs Slow in {
+  it should "draw most games against itself" in {
     val mctsX  = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = true,  iterations = 500)
     val mctsO  = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = false, iterations = 500)
     val runner = TicTacToeGameRunner(mctsX, mctsO, new Random(3L))
@@ -57,7 +57,7 @@ class MCTSPlayerSpec extends AnyFlatSpec with should.Matchers {
     stats.drawsFor(true) should be > 15
   }
 
-  it should "improve with more iterations — fewer losses against random" taggedAs Slow in {
+  it should "improve with more iterations — fewer losses against random" in {
     val rng = new Random(4L)
 
     // Low iterations baseline.
@@ -101,26 +101,81 @@ class MCTSPlayerSpec extends AnyFlatSpec with should.Matchers {
     mcts.chooseMove(win, new Random(1L)) shouldBe None
   }
 
-  it should "win more than it loses as X against a random player" taggedAs Slow in {
+  it should "win more than it loses as X against a random player" in {
     val mcts   = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)
     val runner = Connect4GameRunner(mcts, new C4RandomPlayer, new Random(5L))
     val stats  = runner.playGames(20)
     stats.winsFor(true) should be > stats.lossesFor(true)
   }
 
-  it should "win more than it loses as O against a random player" taggedAs Slow in {
+  it should "win more than it loses as O against a random player" in {
     val mcts   = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = false, iterations = 200)
     val runner = Connect4GameRunner(new C4RandomPlayer, mcts, new Random(6L))
     val stats  = runner.playGames(20)
     stats.winsFor(false) should be > stats.lossesFor(false)
   }
 
-  it should "be competitive against HeuristicPlayer" taggedAs Slow in {
+  it should "be competitive against HeuristicPlayer" in {
     val mcts      = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 500)
     val heuristic = new C4HeuristicPlayer
     val runner    = Connect4GameRunner(mcts, heuristic, new Random(7L))
     val stats     = runner.playGames(10)
     // MCTS with 500 iterations should not be completely dominated.
     stats.winsFor(true) + stats.drawsFor(true) should be > 0
+  }
+  // ---------------------------------------------------------------------------
+  // Tree reuse
+  // ---------------------------------------------------------------------------
+
+  behavior of "MCTSPlayer tree reuse"
+
+  it should "return consistent moves across calls on the same player instance" in {
+    // The same MCTSPlayer instance is reused across multiple chooseMove calls
+    // within a game. Tree reuse must not corrupt state between calls.
+    val mcts = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 100)
+    val rng = new Random(42L)
+    var s = Connect4.start
+    // Play 6 moves (3 each), reusing the same mcts instance throughout.
+    for i <- 0 until 6 do
+      val isX = i % 2 == 0
+      if isX then
+        val move = mcts.chooseMove(s, rng)
+        move shouldBe defined
+        s.open should contain(move.get)
+        s = s.play(move.get, isX = true)
+      else
+        // Opponent plays randomly.
+        s = s.play(s.open(rng.nextInt(s.open.size)), isX = false)
+    // After 6 moves the board should have 6 pieces.
+    (java.lang.Long.bitCount(s.xBits) + java.lang.Long.bitCount(s.oBits)) shouldBe 6
+  }
+
+  it should "still choose a valid move after a cache miss (opponent plays unexplored line)" in {
+    // Force a cache miss by giving the opponent a fresh random player whose
+    // move may not have been explored in the previous search.
+    val mcts = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 50)
+    val rng = new Random(99L)
+    var s = Connect4.start
+    // Move 1: MCTS picks for X.
+    val m1 = mcts.chooseMove(s, rng)
+    m1 shouldBe defined
+    s = s.play(m1.get, isX = true)
+    // Opponent plays col 0 regardless (likely unexplored at depth 2).
+    s = s.play(0, isX = false)
+    // Move 2: MCTS must still return a valid move after the potential cache miss.
+    val m2 = mcts.chooseMove(s, rng)
+    m2 shouldBe defined
+    s.open should contain(m2.get)
+  }
+
+  it should "produce a valid game with tree reuse enabled" taggedAs Slow in {
+    // Play a complete game using the same MCTS instance; verify it terminates
+    // and produces a valid result (no exception, board makes sense).
+    val mcts = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 50)
+    val runner = Connect4GameRunner(mcts, new C4RandomPlayer, new Random(11L))
+    val result = runner.playGame()
+    result.keys should contain(true)
+    result.keys should contain(false)
+    result(true) + result(false) shouldBe 0 // zero-sum
   }
 }

--- a/src/test/scala/com/phasmidsoftware/gambit/game/MCTSPlayerSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/game/MCTSPlayerSpec.scala
@@ -6,6 +6,7 @@ import com.phasmidsoftware.gambit.examples.tictactoe.TicTacToe.TicTacToeState$
 import com.phasmidsoftware.gambit.examples.tictactoe.{Board, TicTacToe, TicTacToeGameRunner, tictactoeGame, RandomPlayer as TTTRandomPlayer}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
+import org.scalatest.tagobjects.Slow
 
 import scala.util.Random
 
@@ -32,21 +33,21 @@ class MCTSPlayerSpec extends AnyFlatSpec with should.Matchers {
     mcts.chooseMove(xWin, new Random(1L)) shouldBe None
   }
 
-  it should "never lose as X against a random player" in {
+  it should "never lose as X against a random player" taggedAs Slow in {
     val mcts   = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = true, iterations = 300)
     val runner = TicTacToeGameRunner(mcts, new TTTRandomPlayer, new Random(1L))
     val stats  = runner.playGames(50)
     stats.winsFor(false) shouldBe 0
   }
 
-  it should "never lose as O against a random player" in {
+  it should "never lose as O against a random player" taggedAs Slow in {
     val mcts   = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = false, iterations = 300)
     val runner = TicTacToeGameRunner(new TTTRandomPlayer, mcts, new Random(2L))
     val stats  = runner.playGames(50)
     stats.winsFor(true) shouldBe 0
   }
 
-  it should "draw most games against itself" in {
+  it should "draw most games against itself" taggedAs Slow in {
     val mctsX  = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = true,  iterations = 500)
     val mctsO  = MCTSPlayer[Board, TicTacToe, Int, Boolean](me = false, iterations = 500)
     val runner = TicTacToeGameRunner(mctsX, mctsO, new Random(3L))
@@ -56,7 +57,7 @@ class MCTSPlayerSpec extends AnyFlatSpec with should.Matchers {
     stats.drawsFor(true) should be > 15
   }
 
-  it should "improve with more iterations — fewer losses against random" in {
+  it should "improve with more iterations — fewer losses against random" taggedAs Slow in {
     val rng = new Random(4L)
 
     // Low iterations baseline.
@@ -100,21 +101,21 @@ class MCTSPlayerSpec extends AnyFlatSpec with should.Matchers {
     mcts.chooseMove(win, new Random(1L)) shouldBe None
   }
 
-  it should "win more than it loses as X against a random player" in {
+  it should "win more than it loses as X against a random player" taggedAs Slow in {
     val mcts   = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 200)
     val runner = Connect4GameRunner(mcts, new C4RandomPlayer, new Random(5L))
     val stats  = runner.playGames(20)
     stats.winsFor(true) should be > stats.lossesFor(true)
   }
 
-  it should "win more than it loses as O against a random player" in {
+  it should "win more than it loses as O against a random player" taggedAs Slow in {
     val mcts   = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = false, iterations = 200)
     val runner = Connect4GameRunner(new C4RandomPlayer, mcts, new Random(6L))
     val stats  = runner.playGames(20)
     stats.winsFor(false) should be > stats.lossesFor(false)
   }
 
-  it should "be competitive against HeuristicPlayer" in {
+  it should "be competitive against HeuristicPlayer" taggedAs Slow in {
     val mcts      = MCTSPlayer[Connect4, Connect4, Int, Boolean](me = true, iterations = 500)
     val heuristic = new C4HeuristicPlayer
     val runner    = Connect4GameRunner(mcts, heuristic, new Random(7L))

--- a/src/test/scala/com/phasmidsoftware/gambit/game/TournamentSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/game/TournamentSpec.scala
@@ -197,9 +197,4 @@ class TournamentSpec extends AnyFlatSpec with should.Matchers {
     val rows = t.standings
     rows.head._1 shouldBe "AB(d=4)"
   }
-
-  it should "produce a complete Connect4Tournament table without throwing" taggedAs Slow in {
-    import com.phasmidsoftware.gambit.examples.connect4.Connect4Tournament
-    noException should be thrownBy Connect4Tournament.run(gamesPerPairing = 2)
-  }
 }

--- a/src/test/scala/com/phasmidsoftware/gambit/game/TournamentSpec.scala
+++ b/src/test/scala/com/phasmidsoftware/gambit/game/TournamentSpec.scala
@@ -1,0 +1,205 @@
+package com.phasmidsoftware.gambit.game
+
+import com.phasmidsoftware.gambit.examples.connect4.Connect4State.given
+import com.phasmidsoftware.gambit.examples.connect4.{Connect4, Connect4State, HeuristicPlayer, RandomPlayer, connect4Game}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import org.scalatest.tagobjects.Slow
+
+import scala.util.Random
+
+class TournamentSpec extends AnyFlatSpec with should.Matchers {
+
+  // Convenience alias.
+  private type C4Tournament = Tournament[Connect4, Connect4, Int, Boolean]
+
+  private def contestant(name: String, player: Player[Connect4, Int, Boolean]) =
+    Contestant(name, player)
+
+  // ---------------------------------------------------------------------------
+  // Contestant
+  // ---------------------------------------------------------------------------
+
+  behavior of "Contestant"
+
+  it should "hold a name and a player" in {
+    val c = Contestant("Random", new RandomPlayer)
+    c.name shouldBe "Random"
+    c.player shouldBe a[RandomPlayer]
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tournament structure
+  // ---------------------------------------------------------------------------
+
+  behavior of "Tournament structure"
+
+  it should "produce standings with one entry per contestant" in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("A", new RandomPlayer),
+        contestant("B", new RandomPlayer),
+      ),
+      gamesPerPairing = 2,
+      random = new Random(1L)
+    )
+    t.standings should have size 2
+  }
+
+  it should "produce standings with the correct column names" in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("A", new RandomPlayer),
+        contestant("B", new RandomPlayer),
+      ),
+      gamesPerPairing = 2,
+      random = new Random(2L)
+    )
+    val rows = t.standings
+    // Each row is (name, played, wins, draws, losses, goalDiff, points).
+    rows.foreach { case (name, p, w, d, l, gd, pts) =>
+      p shouldBe w + d + l
+      pts shouldBe w * 3 + d
+      gd shouldBe w - l
+    }
+  }
+
+  it should "give each contestant the correct number of games played" in {
+    // 3 contestants, gamesPerPairing=2.
+    // Each contestant plays against 2 opponents, in both roles -> 2*2*2 = 8 games each.
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("A", new RandomPlayer),
+        contestant("B", new RandomPlayer),
+        contestant("C", new RandomPlayer),
+      ),
+      gamesPerPairing = 2,
+      random = new Random(3L)
+    )
+    t.standings.foreach { case (_, played, _, _, _, _, _) =>
+      played shouldBe (3 - 1) * 2 * 2 // 2 opponents * 2 directions * 2 games
+    }
+  }
+
+  it should "have standings sorted by points descending" in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("A", new RandomPlayer),
+        contestant("B", new RandomPlayer),
+        contestant("C", new RandomPlayer),
+      ),
+      gamesPerPairing = 4,
+      random = new Random(4L)
+    )
+    val pts = t.standings.map(_._7)
+    pts shouldBe pts.sorted.reverse
+  }
+
+  it should "have zero-sum totals: total wins == total losses across all contestants" in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("A", new RandomPlayer),
+        contestant("B", new RandomPlayer),
+        contestant("C", new RandomPlayer),
+      ),
+      gamesPerPairing = 2,
+      random = new Random(5L)
+    )
+    val rows = t.standings
+    val totalWins = rows.map(_._3).sum
+    val totalLosses = rows.map(_._5).sum
+    totalWins shouldBe totalLosses
+  }
+
+  // ---------------------------------------------------------------------------
+  // League table formatting
+  // ---------------------------------------------------------------------------
+
+  behavior of "Tournament.leagueTable"
+
+  it should "contain a header row with column labels" in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("Random", new RandomPlayer),
+        contestant("Heuristic", new HeuristicPlayer),
+      ),
+      gamesPerPairing = 2,
+      random = new Random(6L)
+    )
+    val table = t.leagueTable
+    table should include("Player")
+    table should include("Pts")
+    table should include("W")
+    table should include("D")
+    table should include("L")
+  }
+
+  it should "contain each contestant's name" in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("Random", new RandomPlayer),
+        contestant("Heuristic", new HeuristicPlayer),
+      ),
+      gamesPerPairing = 2,
+      random = new Random(7L)
+    )
+    val table = t.leagueTable
+    table should include("Random")
+    table should include("Heuristic")
+  }
+
+  it should "have one data row per contestant" in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("A", new RandomPlayer),
+        contestant("B", new RandomPlayer),
+        contestant("C", new RandomPlayer),
+      ),
+      gamesPerPairing = 2,
+      random = new Random(8L)
+    )
+    // Header + separator + 3 data rows = 5 lines minimum.
+    val lines = t.leagueTable.split('\n').toSeq
+    lines.count(l => l.startsWith("1.") || l.startsWith("2.") || l.startsWith("3.")) shouldBe 3
+  }
+
+  // ---------------------------------------------------------------------------
+  // Competitive ordering (slow: plays real games)
+  // ---------------------------------------------------------------------------
+
+  behavior of "Tournament competitive ordering"
+
+  it should "rank HeuristicPlayer above RandomPlayer" taggedAs Slow in {
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("Random", new RandomPlayer),
+        contestant("Heuristic", new HeuristicPlayer),
+      ),
+      gamesPerPairing = 10,
+      random = new Random(10L)
+    )
+    val rows = t.standings
+    val hRank = rows.indexWhere(_._1 == "Heuristic")
+    val rRank = rows.indexWhere(_._1 == "Random")
+    hRank should be < rRank
+  }
+
+  it should "rank AlphaBeta above RandomPlayer" taggedAs Slow in {
+    val ab = AlphaBetaPlayer[Connect4, Connect4, Int, Boolean](me = true, depth = 4)
+    val t = Tournament[Connect4, Connect4, Int, Boolean](
+      contestants = Seq(
+        contestant("Random", new RandomPlayer),
+        contestant("AB(d=4)", ab),
+      ),
+      gamesPerPairing = 10,
+      random = new Random(11L)
+    )
+    val rows = t.standings
+    rows.head._1 shouldBe "AB(d=4)"
+  }
+
+  it should "produce a complete Connect4Tournament table without throwing" taggedAs Slow in {
+    import com.phasmidsoftware.gambit.examples.connect4.Connect4Tournament
+    noException should be thrownBy Connect4Tournament.run(gamesPerPairing = 2)
+  }
+}


### PR DESCRIPTION
- Implement AlphaBetaPlayer[P, S, M, Pl] with configurable depth and move ordering by heuristic for early pruning
- Fix initial alpha bound: use -Double.MaxValue, not Double.MinValue (Double.MinValue is ~5e-324, not negative infinity)
- Return heuristic at leaf nodes from me's perspective by negating when the minimizing player just moved
- Add AlphaBetaPlayerSpec covering TicTacToe and Connect4: terminal detection, winning moves, blocking, never-lose, draw-against-itself
- Add taggedAs Slow to all multi-game and deep-search tests in AlphaBetaPlayerSpec, MCTSPlayerSpec, Connect4GameSpec, Connect4DemoSpec
- Split CircleCI test step into fast (excludes Slow) and slow (Slow only); slow job runs on main branch only, after build passes